### PR TITLE
fix multiple actions/resources, add module defaults group

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,8 @@
 ---
 requires_ansible: '>=2.14.0'
+action_groups:
+  all:
+    - minio_bucket
+    - minio_policy
+    - minio_user
+

--- a/plugins/modules/minio_policy.py
+++ b/plugins/modules/minio_policy.py
@@ -158,8 +158,8 @@ def main():
         data["Statement"].append(
             {
                 "Effect": statement["effect"],
-                "Action": [",".join(statement["action"])],
-                "Resource": [",".join(statement["resource"])],
+                "Action": [statement["action"]] if type(statement["action"]) is str else statement["action"],
+                "Resource": [statement["resource"]] if type(statement["resource"]) is str else statement["resource"],
             }
         )
 


### PR DESCRIPTION
This PR is similar to #1, but supports the use case where there's only a single action/resource.

We also added an action group, so you can use something like this to specify credentials for multiple tasks:
```
module_defaults:
    group/dubzland.minio.all:
      auth:
        access_key: admin
        secret_key: "{{ vault_minio_admin_password }}"
        url: "…"
```